### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -12,6 +12,8 @@ jobs:
     name: Versioning
     runs-on: ubuntu-latest
     if: github.repository == 'mauroalderete/action-assign-labels'
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.semver.outputs.next }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/dupuy/action-assign-labels/security/code-scanning/2](https://github.com/dupuy/action-assign-labels/security/code-scanning/2)

To fix the problem, add an explicit `permissions:` block that grants only the minimal scopes needed by this workflow. The steps that push tags and create releases require write access to repository contents. They do not interact with issues, pull requests, or other resources, so we can restrict the token to `contents: write` only.

The best minimal fix without changing functionality is to add a `permissions:` block at the job level under `jobs.versioning`, because there is a single job in this workflow. This will override any broader repository/organization defaults just for this job while leaving other workflows unaffected. Concretely, in `.github/workflows/versioning.yml`, under the `versioning` job (after `runs-on` or `if`), add:

```yaml
permissions:
  contents: write
```

No new imports or other definitions are needed; this is purely a YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
